### PR TITLE
Create point-blank_shot.js

### DIFF
--- a/point-blank_shot.js
+++ b/point-blank_shot.js
@@ -1,0 +1,17 @@
+(async () => {
+if (actor) {
+  if ((actor.data.data.customModifiers['damage'] || []).some(modifier => modifier.name === 'Point-Blank Shot')) {
+    await actor.removeCustomModifier('damage', 'Point-Blank Shot')
+    if (token.data.effects.includes("systems/pf2e/icons/features/classes/precision.jpg")) {
+      token.toggleEffect("systems/pf2e/icons/features/classes/precision.jpg")
+    }
+  } else {
+    await actor.addCustomModifier('damage', 'Point-Blank Shot', 2, 'circumstance');
+    if (!token.data.effects.includes("systems/pf2e/icons/features/classes/precision.jpg")) {
+      token.toggleEffect("systems/pf2e/icons/features/classes/precision.jpg")
+    }
+  }
+} else {
+  ui.notifications.warn("You must have an actor selected.");
+}
+})(); 


### PR DESCRIPTION
Sadly it adds damage to melee as well. I haven't found a way to only add damage to "Shortbow". If you find a way, let me know!